### PR TITLE
Fix HTTPS upload

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,11 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>deploy-to-scijava</releaseProfiles>
+
+		<jackrabbit-webdav.version>2.19.1</jackrabbit-webdav.version>
+		<apache-httpclient.version>4.5.6</apache-httpclient.version>
+		<apache-httpcore.version>4.4.11</apache-httpcore.version>
+		<imagej-updater.version>0.10.1</imagej-updater.version>
 	</properties>
 
 	<repositories>
@@ -108,9 +113,26 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 
 		<!-- Third-party dependencies -->
 		<dependency>
-			<groupId>net.iharder</groupId>
-			<artifactId>base64</artifactId>
-			<version>2.3.8</version>
+			<groupId>org.apache.jackrabbit</groupId>
+			<artifactId>jackrabbit-webdav</artifactId>
+			<version>${jackrabbit-webdav.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpclient</artifactId>
+			<version>${apache-httpclient.version}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>commons-logging</groupId>
+					<artifactId>commons-logging</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<dependency>
+			<groupId>org.apache.httpcomponents</groupId>
+			<artifactId>httpcore</artifactId>
+			<version>${apache-httpcore.version}</version>
 		</dependency>
 
 		<!-- Test dependencies -->
@@ -122,12 +144,6 @@ Institute of Molecular Cell Biology and Genetics.</license.copyrightOwners>
 		<dependency>
 			<groupId>net.imagej</groupId>
 			<artifactId>imagej-updater</artifactId>
-			<classifier>tests</classifier>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.scijava</groupId>
-			<artifactId>scijava-common</artifactId>
 			<classifier>tests</classifier>
 			<scope>test</scope>
 		</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,18 @@
 				<role>maintainer</role>
 			</roles>
 		</developer>
+		<developer>
+			<name>Deborah Schmidt</name>
+			<url>http://imagej.net/User:Frauzufall</url>
+			<roles>
+				<role>developer</role>
+				<role>debugger</role>
+				<role>reviewer</role>
+				<role>support</role>
+				<role>maintainer</role>
+			</roles>
+			<properties><id>frauzufall</id></properties>
+		</developer>
 	</developers>
 	<contributors>
 		<contributor>

--- a/src/main/java/net/imagej/plugins/uploaders/webdav/ProgressHttpEntityWrapper.java
+++ b/src/main/java/net/imagej/plugins/uploaders/webdav/ProgressHttpEntityWrapper.java
@@ -1,0 +1,126 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2019 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 Felix Schulze
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package net.imagej.plugins.uploaders.webdav;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.entity.HttpEntityWrapper;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * HttpEntityWrapper with a progress callback
+ *
+ * @see <a href="http://stackoverflow.com/a/7319110/268795">http://stackoverflow.com/a/7319110/268795</a>
+ */
+
+class ProgressHttpEntityWrapper extends HttpEntityWrapper {
+
+    private final ProgressCallback progressCallback;
+
+    private long contentLength;
+
+
+    public interface ProgressCallback {
+        void progress(float progress);
+    }
+
+    public ProgressHttpEntityWrapper(final HttpEntity entity, final ProgressCallback progressCallback, final long contentLength) {
+        super(entity);
+        this.progressCallback = progressCallback;
+        this.contentLength = contentLength;
+    }
+
+    @Override
+    public void writeTo(final OutputStream out) throws IOException {
+        this.wrappedEntity.writeTo(out instanceof ProgressFilterOutputStream ? out : new ProgressFilterOutputStream(out, this.progressCallback, contentLength));
+    }
+
+    static class ProgressFilterOutputStream extends FilterOutputStream {
+
+        private final ProgressCallback progressCallback;
+        private long transferred;
+        private long totalBytes;
+
+        ProgressFilterOutputStream(final OutputStream out, final ProgressCallback progressCallback, final long totalBytes) {
+            super(out);
+            this.progressCallback = progressCallback;
+            this.transferred = 0;
+            this.totalBytes = totalBytes;
+        }
+
+        @Override
+        public void write(final byte[] b, final int off, final int len) throws IOException {
+            out.write(b, off, len);
+            this.transferred += len;
+            this.progressCallback.progress(getCurrentProgress());
+        }
+
+        @Override
+        public void write(final int b) throws IOException {
+            out.write(b);
+            this.transferred++;
+            this.progressCallback.progress(getCurrentProgress());
+        }
+
+        private float getCurrentProgress() {
+            return ((float) this.transferred / this.totalBytes);
+        }
+
+    }
+
+}

--- a/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUpdaterITCase.java
+++ b/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUpdaterITCase.java
@@ -31,28 +31,24 @@
 
 package net.imagej.plugins.uploaders.webdav;
 
-import java.io.IOException;
-import java.net.HttpURLConnection;
-import java.net.URL;
-
-import net.imagej.plugins.uploaders.webdav.WebDAVUploader;
 import net.imagej.updater.AbstractUploaderTestBase;
-
 import org.junit.Test;
 
+import java.io.IOException;
 /**
  * A conditional JUnit test for uploading via WebDAV.
  * 
- * This test is only activated iff the following system properties are set:
+ * <p>This test is only activated iff the following system properties are set:
  * <dl>
  * <dt>webdav.test.url</dt><dd>The URL of the update site</dd>
  * <dt>webdav.test.username</dt><dd>The name of the WebDAV account with write permission to the URL</dd>
  * <dt>webdav.test.password</dt><dd>The password of the WebDAV account with write permission to the URL</dd>
- * </dl>
+ * </dl></p>
  * 
- * Any files in the given directory will be deleted before running the test!
+ * <p>Any files in the given directory will be deleted before running the test!</p>
  * 
  * @author Johannes Schindelin
+ * @author Deborah Schmidt
  */
 public class WebDAVUpdaterITCase extends AbstractUploaderTestBase {
 	public WebDAVUpdaterITCase() {
@@ -70,6 +66,7 @@ public class WebDAVUpdaterITCase extends AbstractUploaderTestBase {
 	private class WebDAVDeleter extends WebDAVUploader implements AbstractUploaderTestBase.Deleter {
 		public WebDAVDeleter(final String username, final String password) {
 			setCredentials(username, password);
+			setBaseUrl(WebDAVUpdaterITCase.this.getURL());
 		}
 
 		@Override
@@ -82,15 +79,12 @@ public class WebDAVUpdaterITCase extends AbstractUploaderTestBase {
 
 		@Override
 		public void delete(final String path) throws IOException {
-			final URL target = new URL(url + path);
-			final boolean isDirectory = path.endsWith("/");
-			final HttpURLConnection connection = isDirectory ?
-					connect("DELETE", target, null) :
-					connect("DELETE", target, null, "Depth", "Infinity");
-			int code = connection.getResponseCode();
-			if (code > 299) {
-				throw new IOException("Could not delete " + url + ": " + code + " " + connection.getResponseMessage());
-			}
+			super.delete(path);
+		}
+
+		@Override
+		public boolean isDeleted(String path) throws IOException {
+			return super.isDeleted(path);
 		}
 	}
 }

--- a/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUploaderTests.java
+++ b/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUploaderTests.java
@@ -1,0 +1,152 @@
+/*
+ * #%L
+ * ImageJ software for multidimensional image processing and analysis.
+ * %%
+ * Copyright (C) 2009 - 2017 Board of Regents of the University of
+ * Wisconsin-Madison, Broad Institute of MIT and Harvard, and Max Planck
+ * Institute of Molecular Cell Biology and Genetics.
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+
+package net.imagej.plugins.uploaders.webdav;
+
+import net.imagej.updater.*;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.RandomAccessFile;
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * A conditional JUnit test for uploading via WebDAV.
+ *
+ * <p>This test is only activated iff the following system properties are set:
+ * <dl>
+ * <dt>webdav.test.url</dt><dd>The URL of the update site</dd>
+ * <dt>webdav.test.username</dt><dd>The name of the WebDAV account with write permission to the URL</dd>
+ * <dt>webdav.test.password</dt><dd>The password of the WebDAV account with write permission to the URL</dd>
+ * </dl></p>
+ *
+ * <p>Any files in the given directory will be deleted before running the test!</p>
+ *
+ * @author Johannes Schindelin
+ * @author Deborah Schmidt
+ */
+public class WebDAVUploaderTests extends AbstractUploaderTestBase {
+
+	private WebDAVUploader uploader;
+	private String base;
+
+	public WebDAVUploaderTests() {
+		super("webdav");
+		uploader = new WebDAVUploader();
+	}
+
+	@Rule
+	public TemporaryFolder folder = new TemporaryFolder();
+
+	@Before
+	public void setupCredentials() {
+		final String username = getProperty("username");
+		final String password = getProperty("password");
+		base = getProperty("url");
+		uploader.setBaseUrl(base);
+		uploader.setCredentials(username, password);
+
+	}
+
+	@Test
+	public void createDirectory() throws Exception {
+		if(uploader.directoryExists("plugin")) {
+			uploader.delete("plugin/");
+		}
+		assertFalse(uploader.directoryExists("plugin"));
+		uploader.ensureDirectoryExists("plugin");
+		assertTrue(uploader.directoryExists("plugin"));
+	}
+
+	@Test
+	public void uploadFileInFolder() throws Exception {
+		File file = createTestFile();
+		uploader.upload(new UploadableFile(file, "plugins/" + file.getName()), null, null);
+	}
+
+	@Test
+	public void uploadFile() throws Exception {
+		File file = createTestFile();
+		uploader.upload(new UploadableFile(file, file.getName()), null, null);
+	}
+
+	@Test
+	public void uploadEmptyFile() throws Exception {
+		File file = folder.newFile();
+		uploader.upload(new UploadableFile(file, file.getName()), null, null);
+	}
+
+	@Test
+	public void testLogin() throws IOException {
+		FilesCollection files = new FilesCollection(folder.getRoot());
+		files.addUpdateSite("test", base, "webdav:" + getProperty("username"), null, 0);
+		FilesUploader fUploader = new FilesUploader(files, "test");
+		assertTrue(uploader.isAllowed());
+	}
+
+	@Test
+	public void testDirectoryExists() throws IOException, WebDAVUploader.UnauthenticatedException {
+		assertTrue(uploader.directoryExists(""));
+	}
+	@Test
+	public void uploadLargeFiles() throws Exception {
+		File file = createTestFile();
+		RandomAccessFile raf = new RandomAccessFile(file, "rw");
+		try {
+			raf.setLength(200*1000*1000);
+		}
+		finally {
+			raf.close();
+		}
+		List<Uploadable> toBeUploaded = new ArrayList<>();
+		toBeUploaded.add(new UploadableFile(file, file.getName()));
+
+		uploader.upload(toBeUploaded, new ArrayList<>());
+	}
+
+	private File createTestFile() throws IOException {
+		File file = folder.newFile("testfile.txt");
+		PrintWriter writer = new PrintWriter(file, "UTF-8");
+		writer.println("The first line");
+		writer.println("The second line");
+		writer.close();
+		return file;
+	}
+}


### PR DESCRIPTION
This PR should fix the upload via HTTPS.

It removes the current implementation using a reflection hack to enable WEBDAV methods such as `PROPFIND`. This only worked with the `HttpURLConnection`, not with `HttpsURLConnection`. 

The new implementation is based on Apache's library `jackrabbit-webdav`. 

References:
Bug report for Java 8: https://bugs.openjdk.java.net/browse/JDK-7016595
Should be fixed in new API (Java 11): https://dzone.com/articles/java-11-standardized-http-client-api  