### PR TITLE
Adds implementation for test checking if file is deleted

### DIFF
--- a/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUpdaterITCase.java
+++ b/src/test/java/net/imagej/plugins/uploaders/webdav/WebDAVUpdaterITCase.java
@@ -35,11 +35,9 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 
-import net.imagej.plugins.uploaders.webdav.WebDAVUploader;
 import net.imagej.updater.AbstractUploaderTestBase;
 
 import org.junit.Test;
-
 /**
  * A conditional JUnit test for uploading via WebDAV.
  * 
@@ -91,6 +89,17 @@ public class WebDAVUpdaterITCase extends AbstractUploaderTestBase {
 			if (code > 299) {
 				throw new IOException("Could not delete " + url + ": " + code + " " + connection.getResponseMessage());
 			}
+		}
+
+		@Override
+		public boolean isDeleted(String path) throws IOException {
+			final URL target = new URL(url + path);
+			final boolean isDirectory = path.endsWith("/");
+			final HttpURLConnection connection = isDirectory ?
+					connect("GET", target, null) :
+					connect("GET", target, null, "Depth", "Infinity");
+			int code = connection.getResponseCode();
+			return code == 404;
 		}
 	}
 }


### PR DESCRIPTION
* depends on https://github.com/imagej/imagej-updater/pull/73:

> The current webdav uploader has a reflection hack overriding the default GET method of a HTTP request by special ones like `DELETE` or `OPTIONS`. For HTTPS, this hack does not work. Therefore, when assuming the DELETE method is called, the GET method is called instead. In case the file is present, it returns `200` - all good. The test is assuming deleting worked and continues..

* by checking if a file is actually deleted, AbstractUploaderTestBase.test() will now fail for HTTPS
* removes unused import